### PR TITLE
Update to GDPR-compatible Visual Recognition instances

### DIFF
--- a/Whats-My-Age-Again/SampleCode.swift
+++ b/Whats-My-Age-Again/SampleCode.swift
@@ -71,7 +71,7 @@ func main(args: [String: Any]) -> [String: Any] {
     
     let apiKey = "your-apikey-here" // This is obtained from your Watson Service credentials.
     let version = "YYYY-MM-DD" // Use the most recent version date compatible with your needs.
-    let visualRecognition = VisualRecognition(apiKey: apiKey, version: version)
+    let visualRecognition = VisualRecognition(version: version, apiKey: apiKey)
     
     visualRecognition.detectFaces(url: imageURL, failure: failure) { allImages in
         // This will be used as temporary storage for our detected faces.


### PR DESCRIPTION
Received an email from IBM regarding the need to migrate to [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation)-compliant instances of Watson Visual Recognition:

> This is the final notification to inform you are required to provision a new IBM Watson Visual Recognition service and generate new authentication keys to utilize the GDPR compliant IBM Watson Visual Recognition service.

After following the steps defined in the [Migration documentation](https://console.bluemix.net/docs/services/visual-recognition/migrate.html#migrating), my IBM Cloud Functions were failing with a mysterious error when calling Watson Visual Recognition:

> invalid-api-key

As it turns out, I had completely missed the fact that some changes had been made to [Authentication](https://github.com/watson-developer-cloud/swift-sdk#authentication) for the Visual Recognition service:

> Visual Recognition uses a form of API key only with instances created before May 23, 2018. Newer instances of Visual Recognition use IAM.

Hilariously, I _also_ missed the update in the documentation for the Visual Recognition service within the [Watson Swift SDK docs](https://github.com/watson-developer-cloud/swift-sdk/tree/master/Source/VisualRecognitionV3#visual-recognition):

> let visualRecognition = VisualRecognition(version: version, apiKey: apiKey)
> ...other stuff
> Note: a different initializer is used for authentication with instances created before May 23, 2018:
> let visualRecognition = VisualRecognition(apiKey: apiKey, version: version)

The only reason I even _noticed_ the change in the order of parameters is because I decided to review the [source code for VisualRecognition.swift](https://github.com/watson-developer-cloud/swift-sdk/blob/master/Source/VisualRecognitionV3/VisualRecognition.swift) and was left wondering why the class had a few different `public init()` methods that I hadn't seen in previous reviews of the code.

After pondering 🤔for a while, I finally realized that the authentication implementation for the `init` method I was using was _different_ than the authentication implementation for the `init` method that the docs suggest for Visual Recognition instances created on/after May 23, 2018.

Problem solved! Hooray for open source! 🎉 