### PR TITLE
add publicly-available video

### DIFF
--- a/Challenges-of-Developer-Relations-for-an-Open-Banking-API/README.md
+++ b/Challenges-of-Developer-Relations-for-an-Open-Banking-API/README.md
@@ -5,5 +5,5 @@
 It's not easy to scale an open banking API to handle hundreds of financial institutions and millions of API connections. Creating a high-quality developer experience requires open developer documentation, open source example code, and self-serve API credentials. We'll talk about the challenges faced when providing an open banking API.
 
 - To be presented at [OpenFinity Days 2025](https://www.openfinity.org/2025-openfinity-days) May 14, 2025
-- Presented at [OpenFinity EXPO 2024](https://www.openfinity.org/expo2024) November 19, 2024 [[Available on Speaker Deck]](https://speakerdeck.com/devwiththehair/challenges-of-developer-relations-for-an-open-banking-api)
+- Presented at [OpenFinity EXPO 2024](https://www.openfinity.org/expo2024) November 19, 2024 [[Available on Speaker Deck]](https://speakerdeck.com/devwiththehair/challenges-of-developer-relations-for-an-open-banking-api), [[Video on YouTube]](https://www.youtube.com/watch?v=3QYGgMB3-0E)
 - Presented at [FDX Spring Global Summit](https://financialdataexchange.org/FDX/Global-Summit-2024.aspx) March 14, 2024 [[Available on Speaker Deck]](https://speakerdeck.com/devwiththehair/challenges-of-developer-relations-for-an-open-banking-api)


### PR DESCRIPTION
Make sure to wait until https://www.openfinity.org/expo2024 publicly makes the video available. Right now it's an unlisted YouTube link available at https://www.openfinity.org/expo/agenda-live.

Will need to wait until it's actually a listed entry on their YouTube channel, ETA November 2025? https://www.youtube.com/@OpenFinity